### PR TITLE
Update leader check

### DIFF
--- a/Scripts/Game/GameMode/Squads/Modded/EC_VONController.c
+++ b/Scripts/Game/GameMode/Squads/Modded/EC_VONController.c
@@ -23,6 +23,7 @@ modded class SCR_VONController
 				return super.ActivateVON(entry, transmitType);
 			}
 			SCR_AIGroup playerGroup = groupsMgr.GetPlayerGroup(localPlayerId);
+			string groupName = playerGroup ? playerGroup.GetGroupName().toLower() : "No Group";
 
 			if (!playerGroup)
 			{
@@ -51,6 +52,7 @@ modded class SCR_VONController
 
 			int factionFreq = playerFaction.GetFactionRadioFrequency();
 			PrintFormat("[Modded VON] Player ID: %1 Faction Frequency: %2", localPlayerId, factionFreq);
+			array<string> whiteListNames = {"pilots", "aviators","pilot"};
 
 			SCR_VONEntryRadio radioEntry = SCR_VONEntryRadio.Cast(entry);
 			if (radioEntry)
@@ -60,7 +62,7 @@ modded class SCR_VONController
 				PrintFormat("[Modded VON] Player ID: %1 attempting to transmit on Frequency: %2", localPlayerId, currentFreq);
 
 				// Block if player is not leader and is using the platoon frequency
-				if (currentFreq == factionFreq && playerGroupController.IsPlayerLeaderOwnGroup()==false)
+				if (currentFreq == factionFreq && playerGroupController.IsPlayerLeaderOwnGroup()==false && !whiteListNames.Contains(groupName))
 				{
 
 					PrintFormat("[Modded VON] [Blocked] Player ID: %1 is NOT the group leader (Leader ID: %2). Cannot transmit on platoon frequency: %3", localPlayerId, leaderID, factionFreq);

--- a/Scripts/Game/GameMode/Squads/Modded/EC_VONController.c
+++ b/Scripts/Game/GameMode/Squads/Modded/EC_VONController.c
@@ -60,7 +60,7 @@ modded class SCR_VONController
 				PrintFormat("[Modded VON] Player ID: %1 attempting to transmit on Frequency: %2", localPlayerId, currentFreq);
 
 				// Block if player is not leader and is using the platoon frequency
-				if (currentFreq == factionFreq && localPlayerId != leaderID)
+				if (currentFreq == factionFreq && playerGroupController.IsPlayerLeaderOwnGroup()==false)
 				{
 
 					PrintFormat("[Modded VON] [Blocked] Player ID: %1 is NOT the group leader (Leader ID: %2). Cannot transmit on platoon frequency: %3", localPlayerId, leaderID, factionFreq);


### PR DESCRIPTION
Use the canonical method to check if a player is a leader, add an exception of the group is called "Pilots" to led aviators have free reign on the net. 